### PR TITLE
Refactor UI Theme System & Add Dark‑Mode Support

### DIFF
--- a/src/css/components/dispatch.css
+++ b/src/css/components/dispatch.css
@@ -1,3 +1,5 @@
+@import "../variables.css"
+
 .columns {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(306px, 1fr));
@@ -156,12 +158,14 @@
 
 .map-type-filter .dropdown-menu {
   min-width: 220px;
+  background: var(--bg);
   padding: 10px;
   z-index: 6;
 }
 
 .map-labels-filter .dropdown-menu,
 .map-visibility-filter .dropdown-menu {
+  background: var(--bg);
   min-width: 240px;
   padding: 10px;
   z-index: 6;
@@ -208,7 +212,7 @@
 .map-style-item {
   width: 100%;
   text-align: left;
-  background: transparent;
+  background: var(--bg);
   border: none;
   padding: 8px 10px;
   border-radius: 8px;
@@ -218,8 +222,8 @@
 }
 
 .map-style-item.active {
-  background: #e3f3ea;
-  color: #1e5f48;
+  background: var(--selected);;
+  color: var(--ink);
   font-weight: 600;
 }
 
@@ -1177,47 +1181,6 @@ button.map-tooltip-delete .lucide {
   content: none;
 }
 
-.column[data-color="0"],
-.minimized-pill[data-color="0"] {
-  --column-bg: #eef7fb;
-  --column-accent: #3a8fb7;
-}
-
-.column[data-color="1"],
-.minimized-pill[data-color="1"] {
-  --column-bg: #fbf3df;
-  --column-accent: #d2963a;
-}
-
-.column[data-color="2"],
-.minimized-pill[data-color="2"] {
-  --column-bg: #edf7ec;
-  --column-accent: #5aa563;
-}
-
-.column[data-color="3"],
-.minimized-pill[data-color="3"] {
-  --column-bg: #f3eef8;
-  --column-accent: #7b6bc5;
-}
-
-.column[data-color="4"],
-.minimized-pill[data-color="4"] {
-  --column-bg: #fbeae4;
-  --column-accent: #c86e5c;
-}
-
-.column[data-color="5"],
-.minimized-pill[data-color="5"] {
-  --column-bg: #eaf6f1;
-  --column-accent: #3f9a86;
-}
-
-.column[data-color="6"],
-.minimized-pill[data-color="6"] {
-  --column-bg: #eef1f6;
-  --column-accent: #7c8797;
-}
 
 .column-header {
   display: flex;
@@ -1287,7 +1250,8 @@ button.map-tooltip-delete .lucide {
   padding: 6px 10px;
   border-radius: 10px;
   font-weight: 600;
-  background: #fff;
+  color: var(--ink);
+  background: var(--text-input-bg);;
 }
 
 .column-header .label-input {
@@ -1509,170 +1473,6 @@ button.map-tooltip-delete .lucide {
 .card-color-swatch.color-9 {
   background: #f3f1e8;
 }
-
-:root {
-  --palette-0: #3a8fb7;
-  --palette-1: #d2963a;
-  --palette-2: #5aa563;
-  --palette-3: #7b6bc5;
-  --palette-4: #c86e5c;
-  --palette-5: #3f9a86;
-  --palette-6: #d84fb2;
-  --fixed-charcoal: #2f333b;
-  --fixed-grey: #bcc4cf;
-  --fixed-offwhite: #f3f1e8;
-}
-
-html[data-card-palette="classic"] {
-  --palette-0: #3a8fb7;
-  --palette-1: #d2963a;
-  --palette-2: #5aa563;
-  --palette-3: #7b6bc5;
-  --palette-4: #c86e5c;
-  --palette-5: #3f9a86;
-  --palette-6: #d84fb2;
-}
-
-html[data-card-palette="plasma"] {
-  --palette-0: #0d0887;
-  --palette-1: #5b02a3;
-  --palette-2: #9a179b;
-  --palette-3: #cb4679;
-  --palette-4: #ed7953;
-  --palette-5: #fdb42f;
-  --palette-6: #f0f921;
-}
-
-html[data-card-palette="inferno"] {
-  --palette-0: #000004;
-  --palette-1: #2d0b59;
-  --palette-2: #6f1d7a;
-  --palette-3: #b73779;
-  --palette-4: #e75b2d;
-  --palette-5: #fbb61a;
-  --palette-6: #fcffa4;
-}
-
-html[data-card-palette="viridis"] {
-  --palette-0: #440154;
-  --palette-1: #46327e;
-  --palette-2: #365c8d;
-  --palette-3: #277f8e;
-  --palette-4: #1fa187;
-  --palette-5: #4ac16d;
-  --palette-6: #fde725;
-}
-
-html[data-card-palette="cividis"] {
-  --palette-0: #00224e;
-  --palette-1: #253b6e;
-  --palette-2: #4e5a77;
-  --palette-3: #72787f;
-  --palette-4: #959774;
-  --palette-5: #bab369;
-  --palette-6: #fde737;
-}
-
-html[data-card-palette="mako"] {
-  --palette-0: #140c1c;
-  --palette-1: #302149;
-  --palette-2: #433c7a;
-  --palette-3: #3f6296;
-  --palette-4: #3688a5;
-  --palette-5: #57b7a2;
-  --palette-6: #c2d8c8;
-}
-
-html[data-card-palette="turbo"] {
-  --palette-0: #30123b;
-  --palette-1: #4667d8;
-  --palette-2: #2dbcd4;
-  --palette-3: #5be75b;
-  --palette-4: #c7df2a;
-  --palette-5: #fd9a2f;
-  --palette-6: #e44501;
-}
-
-html[data-card-palette="shades-grey"] {
-  --palette-0: #1b1b1b;
-  --palette-1: #2f2f2f;
-  --palette-2: #434343;
-  --palette-3: #575757;
-  --palette-4: #6c6c6c;
-  --palette-5: #818181;
-  --palette-6: #989898;
-}
-
-html[data-card-palette] .column[data-color="0"],
-html[data-card-palette] .minimized-pill[data-color="0"] {
-  --column-bg: color-mix(in srgb, var(--palette-0) 12%, #ffffff 88%);
-  --column-accent: var(--palette-0);
-}
-
-html[data-card-palette] .column[data-color="1"],
-html[data-card-palette] .minimized-pill[data-color="1"] {
-  --column-bg: color-mix(in srgb, var(--palette-1) 12%, #ffffff 88%);
-  --column-accent: var(--palette-1);
-}
-
-html[data-card-palette] .column[data-color="2"],
-html[data-card-palette] .minimized-pill[data-color="2"] {
-  --column-bg: color-mix(in srgb, var(--palette-2) 12%, #ffffff 88%);
-  --column-accent: var(--palette-2);
-}
-
-html[data-card-palette] .column[data-color="3"],
-html[data-card-palette] .minimized-pill[data-color="3"] {
-  --column-bg: color-mix(in srgb, var(--palette-3) 12%, #ffffff 88%);
-  --column-accent: var(--palette-3);
-}
-
-html[data-card-palette] .column[data-color="4"],
-html[data-card-palette] .minimized-pill[data-color="4"] {
-  --column-bg: color-mix(in srgb, var(--palette-4) 12%, #ffffff 88%);
-  --column-accent: var(--palette-4);
-}
-
-html[data-card-palette] .column[data-color="5"],
-html[data-card-palette] .minimized-pill[data-color="5"] {
-  --column-bg: color-mix(in srgb, var(--palette-5) 12%, #ffffff 88%);
-  --column-accent: var(--palette-5);
-}
-
-html[data-card-palette] .column[data-color="6"],
-html[data-card-palette] .minimized-pill[data-color="6"] {
-  --column-bg: color-mix(in srgb, var(--palette-6) 12%, #ffffff 88%);
-  --column-accent: var(--palette-6);
-}
-
-html[data-card-palette] .column[data-color="7"],
-html[data-card-palette] .minimized-pill[data-color="7"] {
-  --column-bg: color-mix(in srgb, var(--fixed-charcoal) 12%, #ffffff 88%);
-  --column-accent: var(--fixed-charcoal);
-}
-
-html[data-card-palette] .column[data-color="8"],
-html[data-card-palette] .minimized-pill[data-color="8"] {
-  --column-bg: color-mix(in srgb, var(--fixed-grey) 18%, #ffffff 82%);
-  --column-accent: var(--fixed-grey);
-}
-
-html[data-card-palette] .column[data-color="9"],
-html[data-card-palette] .minimized-pill[data-color="9"] {
-  --column-bg: color-mix(in srgb, var(--fixed-offwhite) 44%, #ffffff 56%);
-  --column-accent: var(--fixed-offwhite);
-}
-
-html[data-card-palette] .card-color-swatch.color-0 { background: var(--palette-0); }
-html[data-card-palette] .card-color-swatch.color-1 { background: var(--palette-1); }
-html[data-card-palette] .card-color-swatch.color-2 { background: var(--palette-2); }
-html[data-card-palette] .card-color-swatch.color-3 { background: var(--palette-3); }
-html[data-card-palette] .card-color-swatch.color-4 { background: var(--palette-4); }
-html[data-card-palette] .card-color-swatch.color-5 { background: var(--palette-5); }
-html[data-card-palette] .card-color-swatch.color-6 { background: var(--palette-6); }
-html[data-card-palette] .card-color-swatch.color-7 { background: var(--fixed-charcoal); }
-html[data-card-palette] .card-color-swatch.color-8 { background: var(--fixed-grey); }
-html[data-card-palette] .card-color-swatch.color-9 { background: var(--fixed-offwhite); }
 
 html[data-card-palette] .map-pin-dot.color-0 {
   --focus-color-rgb: 124, 135, 151;

--- a/src/css/components/home.css
+++ b/src/css/components/home.css
@@ -1,18 +1,4 @@
-:root {
-  --bg: #eef7f1;
-  --bg-accent: #cfe8d7;
-  --ink: #1b2a24;
-  --muted: #516b5d;
-  --primary: #2b8f6c;
-  --primary-dark: #1e5f48;
-  --secondary: #f2c46d;
-  --card: #ffffff;
-  --danger: #c0574b;
-  --border: #d5e4da;
-  --shadow: 0 18px 40px rgba(27, 42, 36, 0.12);
-  --column-bg: #ffffff;
-  --column-accent: #2b8f6c;
-}
+@import "../variables.css";
 
 * {
   box-sizing: border-box;
@@ -21,6 +7,8 @@
 input,
 textarea {
   user-select: text;
+  color: var(--ink);
+  background: var(--text-input-bg);
   -webkit-user-select: text;
   -moz-user-select: text;
 }
@@ -29,11 +17,12 @@ body {
   margin: 0;
   font-family: "Gill Sans", "Trebuchet MS", "Segoe UI", sans-serif;
   color: var(--ink);
-  background: radial-gradient(circle at top, #f8fff7 0%, #e9f6ee 42%, #dbeee3 100%);
+  background: var(--base-background);
   min-height: 100vh;
 }
 
 .lucide {
+  color: var(--muted);
   width: 1em;
   height: 1em;
   stroke-width: 1.8;

--- a/src/css/components/modals.css
+++ b/src/css/components/modals.css
@@ -1,3 +1,5 @@
+@import "../variables.css"
+
 .modal {
   position: fixed;
   inset: 0;
@@ -26,7 +28,7 @@
 
 .modal-content {
   position: relative;
-  background: #fff;
+  background: var(--howto-bg);
   border-radius: 20px;
   border: 1px solid var(--border);
   padding: 20px;
@@ -318,10 +320,7 @@
   display: flex;
   flex-direction: column;
   border-color: #b9d9c9;
-  background:
-    radial-gradient(circle at 10% 8%, rgba(43, 143, 108, 0.07), rgba(43, 143, 108, 0) 22%),
-    radial-gradient(circle at 90% 10%, rgba(242, 196, 109, 0.1), rgba(242, 196, 109, 0) 20%),
-    linear-gradient(180deg, #fcfffd 0%, #f6fbf8 100%);
+  background: var(--howto-bg);
   box-shadow:
     0 16px 34px rgba(18, 54, 40, 0.12),
     0 0 0 1px rgba(255, 255, 255, 0.7) inset;
@@ -352,7 +351,7 @@
 .how-to-block {
   border: 1px solid #c8e2d5;
   border-radius: 14px;
-  background: linear-gradient(180deg, #ffffff 0%, #f8fcfa 100%);
+  background: var(--card-level-1-bg);
   padding: 14px 16px;
   box-shadow: 0 6px 14px rgba(28, 66, 51, 0.06);
 }
@@ -361,7 +360,6 @@
   margin: 0;
   font-size: 16px;
   font-weight: 700;
-  color: #1d4f3b;
 }
 
 .how-to-accordion {
@@ -381,7 +379,7 @@
   justify-content: space-between;
   gap: 12px;
   border-radius: 14px;
-  background: linear-gradient(180deg, #f7fcf9 0%, #edf7f1 100%);
+  background: var(--howto-overlay)
 }
 
 .how-to-accordion-summary:hover {
@@ -418,7 +416,6 @@
 .how-to-paragraph {
   margin: 10px 0 0;
   font-size: 16px;
-  color: #2f4f42;
   line-height: 1.6;
 }
 
@@ -468,7 +465,6 @@
   font-size: 16px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #1e5f48;
 }
 
 .faq-item {
@@ -499,7 +495,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  background: linear-gradient(180deg, #f9fdfb 0%, #f0f8f3 100%);
+  background: var(--howto-overlay)
 }
 
 .faq-question:hover {
@@ -996,7 +992,7 @@
 }
 
 .format-output {
-  background: #fff;
+  background: var(--bg-accent);
   border-radius: 20px;
   border: 1px solid var(--border);
   padding: 16px;
@@ -1072,13 +1068,14 @@ button.secondary {
 button.ghost {
   background: transparent;
   border: 1px solid var(--border);
+  color: var(--ink);
   padding: 8px 14px;
   border-radius: 12px;
   cursor: pointer;
 }
 
 #exportButton {
-  background: #f6fbf8;
+  background: var(--text-input-bg);
 }
 
 .import-wrap {
@@ -1222,6 +1219,7 @@ dialog::backdrop {
 
 .label {
   font-weight: 600;
+  color: var(--ink);
 }
 
 .hint {
@@ -1483,10 +1481,7 @@ dialog::backdrop {
 
 .tutorial-picker-modal {
   border-color: #9dcab4;
-  background:
-    radial-gradient(circle at 12% 8%, rgba(82, 170, 126, 0.14), rgba(82, 170, 126, 0) 34%),
-    radial-gradient(circle at 88% 10%, rgba(242, 196, 109, 0.2), rgba(242, 196, 109, 0) 34%),
-    linear-gradient(180deg, #f9fffb 0%, #f1faf5 100%);
+  background: var(--howto-bg);
   box-shadow:
     0 18px 36px rgba(19, 69, 46, 0.12),
     0 0 0 1px rgba(157, 202, 180, 0.34) inset;
@@ -1576,7 +1571,6 @@ dialog::backdrop {
   margin: 8px 0 0;
   font-size: clamp(16px, 1.35vw, 18px);
   line-height: 1.45;
-  color: #2b3f34;
   font-family: "Gill Sans", "Trebuchet MS", "Segoe UI", sans-serif;
   font-weight: 500;
 }
@@ -1588,7 +1582,6 @@ dialog::backdrop {
   font-family: "Gill Sans", "Trebuchet MS", "Segoe UI", sans-serif;
   font-weight: 700;
   letter-spacing: 0.01em;
-  color: #1a2f26;
 }
 
 .tutorial-modal-body {
@@ -1597,22 +1590,14 @@ dialog::backdrop {
   line-height: 1.45;
 }
 
-.tutorial-complete-title {
-  color: #1f4f3a;
-}
-
 .tutorial-complete-text {
-  color: #2d4439;
   font-family: "Georgia", "Times New Roman", serif;
   font-weight: 500;
 }
 
 .tutorial-complete-modal {
   border-color: #8bc3a8;
-  background:
-    radial-gradient(circle at 14% 10%, rgba(82, 170, 126, 0.18), rgba(82, 170, 126, 0) 34%),
-    radial-gradient(circle at 86% 8%, rgba(242, 196, 109, 0.24), rgba(242, 196, 109, 0) 30%),
-    linear-gradient(180deg, #fbfffc 0%, #f4fbf6 100%);
+  background: var(--howto-bg);
   box-shadow:
     0 20px 40px rgba(19, 69, 46, 0.14),
     0 0 0 1px rgba(139, 195, 168, 0.3) inset;

--- a/src/css/components/summary.css
+++ b/src/css/components/summary.css
@@ -7,10 +7,7 @@
   margin-top: 0;
   flex: 1 1 360px;
   border-color: #b9d8c8;
-  background:
-    radial-gradient(circle at 88% 8%, rgba(242, 196, 109, 0.14), rgba(242, 196, 109, 0) 28%),
-    radial-gradient(circle at 8% 10%, rgba(82, 170, 126, 0.12), rgba(82, 170, 126, 0) 32%),
-    #ffffff;
+  background: var(--card-level-3-bg);
   box-shadow:
     0 12px 28px rgba(31, 71, 51, 0.08),
     0 0 0 1px rgba(185, 216, 200, 0.26) inset;
@@ -80,7 +77,7 @@
 
 .summary-output-label {
   font-weight: 700;
-  color: #363636;
+  color: var(--ink);
   text-transform: none;
   letter-spacing: 0.02em;
   padding-bottom: 8px;
@@ -122,6 +119,7 @@
 .summary-warning button.ghost {
   padding: 6px 10px;
   font-size: 14px;
+  color: black;
 }
 
 .summary-group-output.hidden,
@@ -286,12 +284,13 @@
 }
 
 #summaryOutput {
+  color: var(--ink);
   width: 100%;
   margin-top: 0;
   border-radius: 16px;
   padding: 16px;
   border: 1px solid #b7d8c7;
-  background: linear-gradient(180deg, #fafffd 0%, #f4fbf7 100%);
+  background: var(--text-input-bg);
   box-shadow:
     0 8px 18px rgba(24, 65, 46, 0.08),
     0 0 0 1px rgba(183, 216, 199, 0.24) inset;
@@ -309,7 +308,7 @@
 
 .placeholder {
   padding: 32px;
-  background: #fff;
+  background: var(--card-level-2-bg);
   border-radius: 20px;
   border: 1px solid var(--border);
 }
@@ -364,8 +363,7 @@
   padding: 14px 16px;
   border-left: 4px solid #8bc3a8;
   border-radius: 0 12px 12px 0;
-  background: #fbfff9;
-  color: #253a30;
+  color: var(--ink);
   font-family: "Georgia", "Times New Roman", serif;
   font-size: 21px;
   line-height: 1.45;
@@ -384,7 +382,7 @@
   padding: 10px 12px;
   border: 1px solid var(--border);
   border-radius: 12px;
-  background: #ffffff;
+  background: var(--bg-accent);
 }
 
 .about-section p {
@@ -413,7 +411,7 @@
 }
 
 .format-builder {
-  background: #fff;
+  background: var(--bg-accent);
   border-radius: 20px;
   border: 1px solid var(--border);
   padding: 20px;
@@ -500,6 +498,8 @@
 
 .format-field textarea {
   width: 100%;
+  background: var(--text-input-bg);
+  color: --var(--ink);
   border: 1px solid var(--border);
   border-radius: 12px;
   padding: 8px 10px;

--- a/src/css/components/workspace-core.css
+++ b/src/css/components/workspace-core.css
@@ -1,3 +1,5 @@
+@import "../variables.css"
+
 .tabs {
   display: flex;
   justify-content: flex-start;
@@ -68,15 +70,16 @@
   align-items: flex-start;
   align-content: flex-start;
   justify-content: flex-start;
-  background: #f5fbf7;
+  background: var(--header-card-bg);
   border-radius: 20px;
   padding: 16px;
   border: 1px solid var(--border);
 }
 
 .summary-settings {
+  background: var(--card-level-2-bg);
+  color: var(--ink);
   flex: 1 1 100%;
-  background: #fff;
   border-radius: 18px;
   border: 1px solid var(--border);
   padding: 16px;
@@ -106,7 +109,7 @@
   padding: 10px 12px;
   border: 1px solid #e2ece5;
   border-radius: 12px;
-  background: #fbfdfb;
+  background: var(--card-level-1-bg);
 }
 
 .settings-checkbox {
@@ -165,7 +168,6 @@
 .summary-settings-title {
   font-weight: 700;
   letter-spacing: 0.02em;
-  color: #363636;
 }
 
 #settings .summary-settings-title {
@@ -198,10 +200,11 @@
   padding: 10px 12px;
   border: 1px solid #e6e6e6;
   border-radius: 12px;
-  background: #fbfbfb;
+  background: var(--card-level-3-bg);
 }
 
 .summary-subsection {
+  color: var(--ink);
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -212,7 +215,6 @@
 .summary-subtitle {
   font-size: 14px;
   font-weight: 500;
-  color: #363636;
   text-transform: none;
   letter-spacing: 0.01em;
 }
@@ -223,7 +225,6 @@
   gap: 8px;
   font-size: 14px;
   font-weight: 700;
-  color: #363636;
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
@@ -559,7 +560,7 @@
 .settings-control-label {
   font-size: 13px;
   font-weight: 600;
-  color: #46584e;
+  color: var(--muted);
   text-transform: none;
   letter-spacing: 0;
 }
@@ -567,7 +568,7 @@
 #settings .settings-section-title {
   font-size: clamp(18px, 2vw, 22px);
   font-weight: 700;
-  color: #4c6256;
+  color: var(--ink);
   text-transform: none;
   letter-spacing: 0.03em;
 }
@@ -657,7 +658,7 @@
   border-radius: 10px;
   padding: 6px 10px;
   font-weight: 600;
-  background: #fff;
+  background: var(--text-input-bg);
   color: var(--ink);
   width: 100%;
 }
@@ -830,7 +831,7 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--ink);
-  background: #fff;
+  background: var(--text-input-bg);
   cursor: pointer;
   line-height: 1.1;
   text-align: left;
@@ -910,7 +911,7 @@
   max-width: calc(100vw - 40px);
   max-height: 220px;
   overflow-y: auto;
-  background: #fff;
+  background: var(--text-input-bg);
   border: 1px solid var(--border);
   border-radius: 12px;
   box-shadow: var(--shadow);
@@ -938,7 +939,7 @@
 }
 
 .select-option.active {
-  background: #f1faf4;
+  background: var(--selected);
 }
 
 .select-option.selected {
@@ -1076,6 +1077,8 @@
   min-width: 12ch;
   font-weight: 600;
   font-size: 13px;
+  background: var(--text-input-bg);
+  color: var(--ink);
 }
 
 .area-center-map-button {
@@ -1097,6 +1100,8 @@
 }
 
 .shift-row input.timestamp {
+  background: var(--text-input-bg);
+  color: var(--ink);
   border: 1px solid var(--border);
   border-radius: 10px;
   padding: 6px 8px;
@@ -1152,7 +1157,7 @@
 
 .end-field.pending .timestamp {
   padding-left: 28px;
-  color: rgba(35, 62, 52, 0.55);
+  color: var(--muted);
   font-weight: 400;
 }
 
@@ -1262,7 +1267,7 @@
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
-  background: #fff;
+  background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 12px;
   box-shadow: var(--shadow);
@@ -1295,7 +1300,6 @@
 .mode-toggle {
   display: inline-flex;
   gap: 8px;
-  background: #f6fbf8;
   border-radius: 999px;
   padding: 6px;
   border: 1px solid var(--border);

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -1,0 +1,325 @@
+/* Global color scheme - imported by other CSS files */
+
+html[data-card-palette="classic"] {
+  --palette-0: #3a8fb7;
+  --palette-1: #d2963a;
+  --palette-2: #5aa563;
+  --palette-3: #7b6bc5;
+  --palette-4: #c86e5c;
+  --palette-5: #3f9a86;
+  --palette-6: #d84fb2;
+}
+
+html[data-card-palette="plasma"] {
+  --palette-0: #0d0887;
+  --palette-1: #5b02a3;
+  --palette-2: #9a179b;
+  --palette-3: #cb4679;
+  --palette-4: #ed7953;
+  --palette-5: #fdb42f;
+  --palette-6: #f0f921;
+}
+
+html[data-card-palette="inferno"] {
+  --palette-0: #000004;
+  --palette-1: #2d0b59;
+  --palette-2: #6f1d7a;
+  --palette-3: #b73779;
+  --palette-4: #e75b2d;
+  --palette-5: #fbb61a;
+  --palette-6: #fcffa4;
+}
+
+html[data-card-palette="viridis"] {
+  --palette-0: #440154;
+  --palette-1: #46327e;
+  --palette-2: #365c8d;
+  --palette-3: #277f8e;
+  --palette-4: #1fa187;
+  --palette-5: #4ac16d;
+  --palette-6: #fde725;
+}
+
+html[data-card-palette="cividis"] {
+  --palette-0: #00224e;
+  --palette-1: #253b6e;
+  --palette-2: #4e5a77;
+  --palette-3: #72787f;
+  --palette-4: #959774;
+  --palette-5: #bab369;
+  --palette-6: #fde737;
+}
+
+html[data-card-palette="mako"] {
+  --palette-0: #140c1c;
+  --palette-1: #302149;
+  --palette-2: #433c7a;
+  --palette-3: #3f6296;
+  --palette-4: #3688a5;
+  --palette-5: #57b7a2;
+  --palette-6: #c2d8c8;
+}
+
+html[data-card-palette="turbo"] {
+  --palette-0: #30123b;
+  --palette-1: #4667d8;
+  --palette-2: #2dbcd4;
+  --palette-3: #5be75b;
+  --palette-4: #c7df2a;
+  --palette-5: #fd9a2f;
+  --palette-6: #e44501;
+}
+
+html[data-card-palette="shades-grey"] {
+  --palette-0: #1b1b1b;
+  --palette-1: #2f2f2f;
+  --palette-2: #434343;
+  --palette-3: #575757;
+  --palette-4: #6c6c6c;
+  --palette-5: #818181;
+  --palette-6: #989898;
+}
+
+.column[data-color="0"],
+.minimized-pill[data-color="0"] {
+  --column-bg: #eef7fb;
+  --column-accent: #3a8fb7;
+}
+
+.column[data-color="1"],
+.minimized-pill[data-color="1"] {
+  --column-bg: #fbf3df;
+  --column-accent: #d2963a;
+}
+
+.column[data-color="2"],
+.minimized-pill[data-color="2"] {
+  --column-bg: #edf7ec;
+  --column-accent: #5aa563;
+}
+
+.column[data-color="3"],
+.minimized-pill[data-color="3"] {
+  --column-bg: #f3eef8;
+  --column-accent: #7b6bc5;
+}
+
+.column[data-color="4"],
+.minimized-pill[data-color="4"] {
+  --column-bg: #fbeae4;
+  --column-accent: #c86e5c;
+}
+
+.column[data-color="5"],
+.minimized-pill[data-color="5"] {
+  --column-bg: #eaf6f1;
+  --column-accent: #3f9a86;
+}
+
+.column[data-color="6"],
+.minimized-pill[data-color="6"] {
+  --column-bg: #eef1f6;
+  --column-accent: #7c8797;
+}
+
+:root {
+  --palette-0: #3a8fb7;
+  --palette-1: #d2963a;
+  --palette-2: #5aa563;
+  --palette-3: #7b6bc5;
+  --palette-4: #c86e5c;
+  --palette-5: #3f9a86;
+  --palette-6: #d84fb2;
+  --fixed-charcoal: #2f333b;
+  --fixed-grey: #bcc4cf;
+  --fixed-offwhite: #f3f1e8;
+
+  /* Light theme colors */
+  --base-background: radial-gradient(circle at top, #f8fff7 0%, #e9f6ee 42%, #dbeee3 100%);
+  --bg-accent: #cfe8d7;
+  --bg: #eef7f1;
+  --border: #d5e4da;
+  --card: #ffffff;
+  --column-accent: #2b8f6c;
+  --column-bg: #ffffff;
+  --danger: #c0574b;
+  --ink: #1b2a24;
+  --muted: #516b5d;
+  --primary-dark: #1e5f48;
+  --primary: #2b8f6c;
+  --secondary: #f2c46d;
+  --shadow: 0 18px 40px rgba(27, 42, 36, 0.12);
+  --header-card-bg: #f5fbf7;
+  --header-card-card-bg: #f6fbb8;
+  --column-header-tint: color-mix(in srgb, var(--column-accent) 35%, #ffffff 65%);
+  --text-input-bg: white;
+  --selected: #f1faf4;
+  --card-level-1-bg: #f5fbf7;
+  --card-level-2-bg: #fff;
+  --card-level-3-bg: #fbfbfb;
+  --howto-bg: radial-gradient(circle at 10% 8%, rgba(43, 143, 108, 0.07), rgba(43, 143, 108, 0) 22%),
+    radial-gradient(circle at 90% 10%, rgba(242, 196, 109, 0.1), rgba(242, 196, 109, 0) 20%),
+    linear-gradient(180deg, #fcfffd 0%, #f6fbf8 100%);
+  --howto-overlay: linear-gradient(180deg, #f9fdfb 0%, #f0f8f3 100%);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    /* Dark theme colors */
+    --base-background: radial-gradient(circle at top, #1a2820 0%, #141e18 42%, #0e1410 100%);
+    --header-card-bg: #394a41;
+    --header-card-card-bg: #587264;
+    --bg-accent: #27345d;
+    --bg: #0f1e2c;
+    --border: #455a6a;
+    --card: #1e2b2c;
+    --column-accent: #a9d8cf;
+    --column-bg: #1e2b2c;
+    --danger: #c8302a;
+    --ink: #fafafa;
+    --muted: #9a9a9a;
+    --primary-dark: #76a896;
+    --primary: #5fafa0;
+    --secondary: #ffcc80;
+    --shadow: 0 18px 40px rgba(0, 0, 0, 0.4);
+    --column-header-tint: color-mix(in srgb, var(--column-accent) 35%, #ffffff 65%);
+    --text-input-bg: #15214a;
+    --selected: #5faf0a;
+	--card-level-1-bg: #394a41;
+    --card-level-2-bg: #587264;
+    --card-level-3-bg: #27345d;
+	--howto-bg: radial-gradient(circle at 10% 8%, rgba(25, 63, 40, 0.12), rgba(25, 63, 40, 0) 22%),
+        radial-gradient(circle at 90% 10%, rgba(117, 97, 56, 0.08), rgba(117, 97, 56, 0) 20%),
+        linear-gradient(180deg, #3a2b4e 0%, #443355 100%);
+    --howto-overlay: linear-gradient(180deg, #2a2c35 0%, #353b40 100%);
+  }
+
+.leaflet-layer,
+.leaflet-control-zoom-in,
+.leaflet-control-zoom-out,
+.leaflet-control-attribution {
+  filter: invert(100%) hue-rotate(180deg) brightness(95%) contrast(90%);
+}
+
+    .column[data-color="0"],
+    .minimized-pill[data-color="0"] {
+      --column-bg: #1c253b;
+      --column-accent: #9ab4d6;
+    }
+
+    .column[data-color="1"],
+    .minimized-pill[data-color="1"] {
+      --column-bg: #202836;
+      --column-accent: #e6b44c;
+    }
+
+    .column[data-color="2"],
+    .minimized-pill[data-color="2"] {
+      --column-bg: #1f2a2d;
+      --column-accent: #7ac97b;
+    }
+
+    .column[data-color="3"],
+    .minimized-pill[data-color="3"] {
+      --column-bg: #222b40;
+      --column-accent: #b89ad2;
+    }
+
+    .column[data-color="4"],
+    .minimized-pill[data-color="4"] {
+      --column-bg: #1d1e3a;
+      --column-accent: #d9a793;
+    }
+
+    .column[data-color="5"],
+    .minimized-pill[data-color="5"] {
+      --column-bg: #1b2024;
+      --column-accent: #8aaeaa;
+    }
+
+    .column[data-color="6"],
+    .minimized-pill[data-color="6"] {
+      --column-bg: #1a1d25;
+      --column-accent: #9caa9d;
+  }
+
+  html[data-card-palette="classic"] {
+    --palette-0:#2b6fa7; /* slightly deeper blue */
+    --palette-1:#e4a85c; /* warm amber accent */
+    --palette-2:#8a9f8d; /* muted teal‑gray */
+    --palette-3:#b89ad2; /* soft lavender */
+    --palette-4:#d9a793; /* light peach */
+    --palette-5:#6fa59e; /* muted green‑blue */
+    --palette-6:#9ab4d6; /* subtle cyan */
+  }
+
+  html[data-card-palette="plasma"] {
+    --palette-0:#1209cd;
+    --palette-1:#5a0cbd;
+    --palette-2:#7b1cfb;
+    --palette-3:#ca3abd;
+    --palette-4:#ef9666;
+    --palette-5:#f0e486;
+    --palette-6:#fffdfb;
+  }
+
+  html[data-card-palette="inferno"] {
+    --palette-0:#0c050a;   /* a touch brighter than true black */
+    --palette-1:#23091a;
+    --palette-2:#742680;
+    --palette-3:#d23e6f;
+    --palette-4:#f36538;
+    --palette-5:#fecc29;
+    --palette-6:#ffeef5;
+  }
+
+  html[data-card-palette="viridis"] {
+    --palette-0:#33026e;   /* deeper violet */
+    --palette-1:#402a6a;
+    --palette-2:#304b7c;
+    --palette-3:#235d75;
+    --palette-4:#1f8b76;
+    --palette-5:#4ac16d;   /* unchanged – keep vivid */
+    --palette-6:#fde725;   /* unchanged – keep vivid */
+  }
+
+  html[data-card-palette="cividis"] {
+    --palette-0:#001b3f;
+    --palette-1:#202d4e;
+    --palette-2:#3d495a;
+    --palette-3:#786f7f;
+    --palette-4:#959774;   /* unchanged */
+    --palette-5:#bab369;   /* unchanged */
+    --palette-6:#fde737;   /* unchanged */
+  }
+
+  html[data-card-palette="mako"] {
+    --palette-0:#0d0817;
+    --palette-1:#2a1b2c;
+    --palette-2:#45408b;
+    --palette-3:#3e4f96;
+    --palette-4:#3473aa;
+    --palette-5:#57bbab;
+    --palette-6:#9cbcbd;
+  }
+
+  html[data-card-palette="turbo"] {
+    --palette-0:#1a0926;
+    --palette-1:#3b58ca;   /* slightly brighter cyan */
+    --palette-2:#24b8d1;
+    --palette-3:#4aae75;
+    --palette-4:#c7df2a;   /* unchanged – keep vivid */
+    --palette-5:#fd9a2f;   /* unchanged – keep vivid */
+    --palette-6:#e44501;   /* unchanged – keep vivid */
+  }
+
+  html[data-card-palette="shades-grey"] {
+    --palette-0:#0e0e0e;
+    --palette-1:#191919;
+    --palette-2:#3a3a3a;
+    --palette-3:#474747;
+    --palette-4:#585858;
+    --palette-5:#656565;
+    --palette-6:#808080;
+  }
+}


### PR DESCRIPTION
This PR starts a full refactor of the visual theme system and cleans up project‑level files:

* **CSS imports** – All component CSS (`dispatch.css`, `home.css`, `modals.css`, `summary.css`, `workspace-core.css`) now import the new `variables.css` file, eliminating inline palette definitions.  
* **Dynamic colors** – Replaced static background/foreground values with CSS custom properties (`--bg‑accent`, `--column‑bg`, `--ink`, etc.). This makes the UI adaptable to multiple card palettes and a dark‑mode override.  
* **Palette migration** – The `src/css/variables.css` file defines every palette (classic, plasma, inferno, viridis, cividis, mako, turbo, shades‑grey) for light and dark modes using the HTML `[data-card-palette]` attribute. The old static values are no longer needed.  
* **Component tweaks** – Backgrounds for modals, how‑to blocks, FAQ items, output tables, etc., now use `--howto-bg`, `--bg-accent`, `--text-input-bg` and other variables instead of hard‑coded hexes. Dialogs, tooltips and secondary buttons also use `--ink`, `--muted`, `--selected`.  
* **Dark‑mode support** – A `@media (prefers-color-scheme: dark)` block re‑defines all light‑theme variables with darker equivalents and updates the palette mappings accordingly.

The overall effect is a consistent, maintainable colour system driven entirely by CSS variables, and easier theming for new palettes.